### PR TITLE
Add ticket file to worktreeFix ticketflow close command when run from worktree - current-ticket.md not found

### DIFF
--- a/tickets/done/250727-014406-fix-close-command-in-worktree.md
+++ b/tickets/done/250727-014406-fix-close-command-in-worktree.md
@@ -33,10 +33,10 @@ The `ticketflow close` command and other commands fail when run from within a wo
 
 ## タスク
 - [x] Implement the fix from ticket 250726-230008 (copy ticket file and create symlink in worktree) - 実装済み
-- [ ] Test `ticketflow close` command from within a worktree
-- [ ] Test other commands that rely on `current-ticket.md` from worktree context
-- [ ] Ensure commands work correctly in both worktree and non-worktree modes
-- [ ] 既存の実装が正しく動作することを確認
+- [x] Test `ticketflow close` command from within a worktree - ✅ テスト完了
+- [x] Test other commands that rely on `current-ticket.md` from worktree context - ✅ 動作確認済み
+- [x] Ensure commands work correctly in both worktree and non-worktree modes - ✅ 両モードで正常動作
+- [x] 既存の実装が正しく動作することを確認 - ✅ 確認完了
 
 ## 技術仕様
 
@@ -54,6 +54,24 @@ Commands affected:
 2. 問題が解決されていない場合は、追加の修正を検討
 3. テストケースの追加を検討
 
+## テスト結果
+
+実装済みの修正が正しく動作することを確認しました：
+
+1. **ワークツリー作成時の動作確認**
+   - `ticketflow start` でワークツリーが正常に作成される
+   - ワークツリー内に `current-ticket.md` シンボリックリンクが作成される
+   - `tickets/doing/` ディレクトリにチケットファイルがコピーされる
+
+2. **ワークツリー内からのコマンド実行**
+   - `ticketflow close` コマンドがワークツリー内から正常に実行できる
+   - 未コミットの変更を正しく検出できる
+   - チケットが doing → done に正しく遷移する
+
+3. **修正の確認**
+   - `StartTicket` 関数（internal/cli/commands.go:384-407）の実装を確認
+   - ワークツリーと通常モードの両方で動作することを確認
+
 ## メモ
 
-This ticket is related to ticket 250726-230008-current-ticket-not-exist.md. The implementation has been completed but needs testing to ensure it works correctly.
+This ticket is related to ticket 250726-230008-current-ticket-not-exist.md. The implementation has been completed and thoroughly tested to ensure it works correctly in both worktree and non-worktree modes.


### PR DESCRIPTION

- ワークツリー内での ticketflow close コマンドの修正が既に実装済みであることを確認
- チケットのドキュメントを現在の実装状況に合わせて更新
- ワークツリー内からのcloseコマンドのテストに成功