### PR TITLE
Improve close error message to suggest restore command

### DIFF
--- a/internal/cli/commands.go
+++ b/internal/cli/commands.go
@@ -1007,6 +1007,17 @@ func (app *App) validateTicketForClose(ctx context.Context, force bool) (*ticket
 	// Get current ticket
 	current, err := app.Manager.GetCurrentTicket(ctx)
 	if err != nil {
+		// Check if this is a symlink error that could be fixed with restore
+		if strings.Contains(err.Error(), "failed to read current ticket link") ||
+			strings.Contains(err.Error(), "symlink") {
+			return nil, "", NewError(ErrTicketNotStarted, "Failed to read current ticket",
+				err.Error(),
+				[]string{
+					"Try restoring the current ticket link: ticketflow restore",
+					"Or start a ticket manually: ticketflow start <ticket-id>",
+					"List available tickets: ticketflow list",
+				})
+		}
 		return nil, "", ConvertError(err)
 	}
 	if current == nil {
@@ -1014,6 +1025,7 @@ func (app *App) validateTicketForClose(ctx context.Context, force bool) (*ticket
 			"There is no ticket currently being worked on",
 			[]string{
 				"Start a ticket first: ticketflow start <ticket-id>",
+				"Restore current ticket link if in a worktree: ticketflow restore",
 				"List available tickets: ticketflow list",
 			})
 	}

--- a/internal/cli/error_converter.go
+++ b/internal/cli/error_converter.go
@@ -47,6 +47,7 @@ func ConvertError(err error) error {
 	case errors.Is(err, ticketerrors.ErrTicketNotStarted):
 		return NewError(ErrTicketNotStarted, "Ticket not started", err.Error(), []string{
 			"Start the ticket first with 'ticketflow start <ticket-id>'",
+			"If in a worktree, try restoring the current ticket link: 'ticketflow restore'",
 		})
 
 	case errors.Is(err, ticketerrors.ErrNotGitRepo):

--- a/tickets/doing/250808-231214-improve-close-error-message-suggest-restore.md
+++ b/tickets/doing/250808-231214-improve-close-error-message-suggest-restore.md
@@ -1,8 +1,8 @@
 ---
 priority: 2
-description: "Improve error message when ticketflow close fails to suggest using ticketflow restore"
+description: Improve error message when ticketflow close fails to suggest using ticketflow restore
 created_at: "2025-08-08T23:12:14+09:00"
-started_at: null
+started_at: "2025-08-08T23:35:16+09:00"
 closed_at: null
 ---
 

--- a/tickets/doing/250808-231214-improve-close-error-message-suggest-restore.md
+++ b/tickets/doing/250808-231214-improve-close-error-message-suggest-restore.md
@@ -17,15 +17,15 @@ Currently, when `ticketflow close` encounters an error, users may not know that 
 ## Tasks
 Make sure to update task status when you finish it. Also, always create a commit for each task you finished.
 
-- [ ] Find where `ticketflow close` command handles errors
-- [ ] Identify the specific error conditions where restore would help (e.g., missing symlink, broken worktree state)
-- [ ] Update error messages to include suggestion about using `ticketflow restore`
-- [ ] Ensure the suggestion is clear and includes the correct command syntax
-- [ ] Test the updated error messages in various failure scenarios
-- [ ] Run `make test` to run the tests
-- [ ] Run `make vet`, `make fmt` and `make lint`
+- [x] Find where `ticketflow close` command handles errors
+- [x] Identify the specific error conditions where restore would help (e.g., missing symlink, broken worktree state)
+- [x] Update error messages to include suggestion about using `ticketflow restore`
+- [x] Ensure the suggestion is clear and includes the correct command syntax
+- [x] Test the updated error messages in various failure scenarios
+- [x] Run `make test` to run the tests
+- [x] Run `make vet`, `make fmt` and `make lint`
 - [ ] Update documentation if necessary
-- [ ] Update the ticket with insights from resolving this ticket
+- [x] Update the ticket with insights from resolving this ticket
 - [ ] Get developer approval before closing
 
 ## Implementation Notes
@@ -40,6 +40,41 @@ Suggestion: If the ticket's symlink or worktree state is corrupted, you can try:
 This will attempt to restore the ticket to a working state.
 ```
 
+## Implementation Details
+
+The improvements were made to three key areas:
+
+1. **validateTicketForClose function** in `internal/cli/commands.go`:
+   - Added detection for symlink-related errors when GetCurrentTicket fails
+   - Added specific error message suggesting `ticketflow restore` when symlink issues are detected
+   - Improved error messages for "No active ticket" scenario to include restore suggestion
+
+2. **ConvertError function** in `internal/cli/error_converter.go`:
+   - Updated the generic ErrTicketNotStarted conversion to include restore suggestion
+   - This ensures consistent messaging across all ticket-not-started errors
+
+3. **Error message improvements**:
+   - "No active ticket" now suggests: `ticketflow restore` as an option
+   - Symlink read failures now explicitly suggest restore as the recovery method
+   - All suggestions are clear with exact command syntax
+
+The actual error messages now provide:
+- Clear indication of the problem
+- Multiple recovery options in order of likelihood
+- Exact command syntax for each suggestion
+
+Example error output:
+```
+Error Code: TICKET_NOT_STARTED
+Message: No active ticket
+Details: There is no ticket currently being worked on
+
+Suggestions:
+  - Start a ticket first: ticketflow start <ticket-id>
+  - Restore current ticket link if in a worktree: ticketflow restore
+  - List available tickets: ticketflow list
+```
+
 ## Notes
 
-This improvement will enhance user experience by providing clear recovery steps when operations fail.
+This improvement will enhance user experience by providing clear recovery steps when operations fail. The implementation follows the existing error handling patterns in the codebase and maintains consistency with other error messages.

--- a/tickets/todo/250808-231214-improve-close-error-message-suggest-restore.md
+++ b/tickets/todo/250808-231214-improve-close-error-message-suggest-restore.md
@@ -1,0 +1,45 @@
+---
+priority: 2
+description: "Improve error message when ticketflow close fails to suggest using ticketflow restore"
+created_at: "2025-08-08T23:12:14+09:00"
+started_at: null
+closed_at: null
+---
+
+# Ticket Overview
+
+When `ticketflow close` command fails (e.g., due to missing symlink or corrupted state), the error message should be more helpful and suggest using `ticketflow restore` to recover the symlink and restore the ticket to a working state.
+
+## Context
+
+Currently, when `ticketflow close` encounters an error, users may not know that they can use `ticketflow restore` to recover from a broken state. This improvement will make the error message more actionable and help users resolve issues more quickly.
+
+## Tasks
+Make sure to update task status when you finish it. Also, always create a commit for each task you finished.
+
+- [ ] Find where `ticketflow close` command handles errors
+- [ ] Identify the specific error conditions where restore would help (e.g., missing symlink, broken worktree state)
+- [ ] Update error messages to include suggestion about using `ticketflow restore`
+- [ ] Ensure the suggestion is clear and includes the correct command syntax
+- [ ] Test the updated error messages in various failure scenarios
+- [ ] Run `make test` to run the tests
+- [ ] Run `make vet`, `make fmt` and `make lint`
+- [ ] Update documentation if necessary
+- [ ] Update the ticket with insights from resolving this ticket
+- [ ] Get developer approval before closing
+
+## Implementation Notes
+
+The error message should be helpful and actionable, something like:
+```
+Error: Failed to close ticket: [original error]
+
+Suggestion: If the ticket's symlink or worktree state is corrupted, you can try:
+  ticketflow restore <ticket-id>
+
+This will attempt to restore the ticket to a working state.
+```
+
+## Notes
+
+This improvement will enhance user experience by providing clear recovery steps when operations fail.


### PR DESCRIPTION
## Summary
- Enhanced error messages in `ticketflow close` command to suggest using `ticketflow restore` when encountering symlink or worktree state issues
- Added helpful recovery suggestions in multiple error scenarios to improve user experience

## Changes
- Modified `validateTicketForClose` in `internal/cli/commands.go` to detect symlink-related errors and provide specific recovery suggestions
- Updated `ConvertError` in `internal/cli/error_converter.go` to include restore suggestion for ticket-not-started errors
- Error messages now provide clear, actionable recovery steps with exact command syntax

## Test Plan
- [x] Verified existing tests pass with `make test`
- [x] Ran code quality checks: `make fmt`, `make vet`, `make lint`
- [x] Manually tested error scenarios to verify helpful messages are displayed
- [ ] Review error message clarity and usefulness

## Example Error Output
When encountering a missing or corrupted symlink:
```
Error Code: TICKET_NOT_STARTED
Message: Failed to read current ticket

Suggestions:
  - Try restoring the current ticket link: ticketflow restore
  - Or start a ticket manually: ticketflow start <ticket-id>
  - List available tickets: ticketflow list
```

Resolves ticket: 250808-231214-improve-close-error-message-suggest-restore

🤖 Generated with [Claude Code](https://claude.ai/code)