### PR TITLE
Migrate init command to new Command interface

### DIFF
--- a/cmd/ticketflow/main.go
+++ b/cmd/ticketflow/main.go
@@ -44,6 +44,13 @@ func init() {
 		// This should never happen in practice but we handle it gracefully
 		fmt.Fprintf(os.Stderr, "Warning: failed to register help command: %v\n", err)
 	}
+
+	// Register init command
+	if err := commandRegistry.Register(commands.NewInitCommand()); err != nil {
+		// Log error but continue - allow program to run with degraded functionality
+		// This should never happen in practice but we handle it gracefully
+		fmt.Fprintf(os.Stderr, "Warning: failed to register init command: %v\n", err)
+	}
 }
 
 func main() {
@@ -173,14 +180,6 @@ func runCLI(ctx context.Context) error {
 
 	// Fall back to old switch statement for unmigrated commands
 	switch os.Args[1] {
-	case "init":
-		return parseAndExecute(ctx, Command{
-			Name: "init",
-			Execute: func(ctx context.Context, fs *flag.FlagSet, flags interface{}) error {
-				return handleInit(ctx)
-			},
-		}, os.Args[2:])
-
 	case "new":
 		return parseAndExecute(ctx, Command{
 			Name:         "new",
@@ -351,11 +350,6 @@ func runCLI(ctx context.Context) error {
 	default:
 		return fmt.Errorf("unknown command: %s", os.Args[1])
 	}
-}
-
-func handleInit(ctx context.Context) error {
-	// Special case: init doesn't require existing config
-	return cli.InitCommand(ctx)
 }
 
 func handleNew(ctx context.Context, slug, parent, format string) error {

--- a/docs/COMMAND_MIGRATION_GUIDE.md
+++ b/docs/COMMAND_MIGRATION_GUIDE.md
@@ -267,6 +267,7 @@ func TestListCommand(t *testing.T) {
 - [x] Add executeNewCommand function
 - [x] **version** command (including -v, --version aliases)
 - [x] **help** command (including -h, --help aliases)
+- [x] **init** - Initialize ticket system
 
 ### In Progress 🚧
 - [ ] Create migration tickets for remaining commands
@@ -274,7 +275,6 @@ func TestListCommand(t *testing.T) {
 ### Pending Migration 📋
 
 #### Simple Commands (No Dependencies)
-- [ ] **init** - Initialize ticket system
 
 #### Read-Only Commands
 - [ ] **status** - Show current ticket status

--- a/internal/cli/commands/help.go
+++ b/internal/cli/commands/help.go
@@ -90,7 +90,6 @@ func (c *HelpCommand) showGeneralHelp() error {
 		usage       string
 		description string
 	}{
-		{"init", "Initialize ticket system"},
 		{"new <slug> [options]", "Create new ticket"},
 		{"list [options]", "List tickets"},
 		{"show <ticket> [options]", "Show ticket details"},

--- a/internal/cli/commands/init.go
+++ b/internal/cli/commands/init.go
@@ -1,0 +1,61 @@
+package commands
+
+import (
+	"context"
+	"flag"
+
+	"github.com/yshrsmz/ticketflow/internal/cli"
+	"github.com/yshrsmz/ticketflow/internal/command"
+)
+
+// InitCommand implements the init command using the new Command interface
+type InitCommand struct{}
+
+// NewInitCommand creates a new init command
+func NewInitCommand() command.Command {
+	return &InitCommand{}
+}
+
+// Name returns the command name
+func (c *InitCommand) Name() string {
+	return "init"
+}
+
+// Aliases returns alternative names for this command
+func (c *InitCommand) Aliases() []string {
+	return nil
+}
+
+// Description returns a short description of the command
+func (c *InitCommand) Description() string {
+	return "Initialize a new ticketflow project"
+}
+
+// Usage returns the usage string for the command
+func (c *InitCommand) Usage() string {
+	return "init"
+}
+
+// SetupFlags configures flags for the command
+func (c *InitCommand) SetupFlags(fs *flag.FlagSet) interface{} {
+	// Init command has no flags
+	return nil
+}
+
+// Validate checks if the command arguments are valid
+func (c *InitCommand) Validate(flags interface{}, args []string) error {
+	// No validation needed for init command
+	// It doesn't require existing config and creates its own structure
+	return nil
+}
+
+// Execute runs the init command
+func (c *InitCommand) Execute(ctx context.Context, flags interface{}, args []string) error {
+	// Delegate to the existing init command implementation
+	// This handles all the initialization logic including:
+	// - Finding the git project root
+	// - Creating default config
+	// - Creating ticket directories
+	// - Updating .gitignore
+	return cli.InitCommand(ctx)
+}

--- a/internal/cli/commands/init_test.go
+++ b/internal/cli/commands/init_test.go
@@ -46,7 +46,11 @@ func TestInitCommand(t *testing.T) {
 		// Create a temporary directory for testing
 		tmpDir, err := os.MkdirTemp("", "ticketflow-init-test-*")
 		require.NoError(t, err)
-		defer os.RemoveAll(tmpDir)
+		defer func() {
+			if err := os.RemoveAll(tmpDir); err != nil {
+				t.Logf("failed to remove temp dir %s: %v", tmpDir, err)
+			}
+		}()
 
 		// Change to temp directory
 		originalWd, err := os.Getwd()
@@ -94,7 +98,11 @@ func TestInitCommand(t *testing.T) {
 		// Create a temporary directory for testing
 		tmpDir, err := os.MkdirTemp("", "ticketflow-init-test-already-*")
 		require.NoError(t, err)
-		defer os.RemoveAll(tmpDir)
+		defer func() {
+			if err := os.RemoveAll(tmpDir); err != nil {
+				t.Logf("failed to remove temp dir %s: %v", tmpDir, err)
+			}
+		}()
 
 		// Change to temp directory
 		originalWd, err := os.Getwd()
@@ -134,7 +142,11 @@ func TestInitCommand(t *testing.T) {
 		// Create a temporary directory for testing (without git init)
 		tmpDir, err := os.MkdirTemp("", "ticketflow-init-test-no-git-*")
 		require.NoError(t, err)
-		defer os.RemoveAll(tmpDir)
+		defer func() {
+			if err := os.RemoveAll(tmpDir); err != nil {
+				t.Logf("failed to remove temp dir %s: %v", tmpDir, err)
+			}
+		}()
 
 		// Change to temp directory
 		originalWd, err := os.Getwd()

--- a/internal/cli/commands/init_test.go
+++ b/internal/cli/commands/init_test.go
@@ -1,0 +1,155 @@
+package commands
+
+import (
+	"context"
+	"flag"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestInitCommand(t *testing.T) {
+	t.Run("command metadata", func(t *testing.T) {
+		cmd := NewInitCommand()
+
+		assert.Equal(t, "init", cmd.Name())
+		assert.Nil(t, cmd.Aliases())
+		assert.Equal(t, "Initialize a new ticketflow project", cmd.Description())
+		assert.Equal(t, "init", cmd.Usage())
+	})
+
+	t.Run("no flags", func(t *testing.T) {
+		cmd := NewInitCommand()
+
+		fs := flag.NewFlagSet("test", flag.ContinueOnError)
+		flags := cmd.SetupFlags(fs)
+
+		assert.Nil(t, flags)
+		assert.Equal(t, 0, fs.NFlag())
+	})
+
+	t.Run("validation always succeeds", func(t *testing.T) {
+		cmd := NewInitCommand()
+
+		err := cmd.Validate(nil, []string{})
+		assert.NoError(t, err)
+
+		err = cmd.Validate(nil, []string{"extra", "args"})
+		assert.NoError(t, err)
+	})
+
+	t.Run("execute creates ticketflow structure", func(t *testing.T) {
+		// Create a temporary directory for testing
+		tmpDir, err := os.MkdirTemp("", "ticketflow-init-test-*")
+		require.NoError(t, err)
+		defer os.RemoveAll(tmpDir)
+
+		// Change to temp directory
+		originalWd, err := os.Getwd()
+		require.NoError(t, err)
+		defer func() {
+			err := os.Chdir(originalWd)
+			require.NoError(t, err)
+		}()
+		require.NoError(t, os.Chdir(tmpDir))
+
+		// Initialize git repo
+		gitInit := exec.Command("git", "init")
+		gitInit.Dir = tmpDir
+		require.NoError(t, gitInit.Run())
+
+		// Configure git locally (not globally) for the test
+		gitConfig := exec.Command("git", "config", "user.name", "Test User")
+		gitConfig.Dir = tmpDir
+		require.NoError(t, gitConfig.Run())
+
+		gitConfigEmail := exec.Command("git", "config", "user.email", "test@example.com")
+		gitConfigEmail.Dir = tmpDir
+		require.NoError(t, gitConfigEmail.Run())
+
+		// Execute the init command
+		cmd := NewInitCommand()
+		err = cmd.Execute(context.Background(), nil, []string{})
+		require.NoError(t, err)
+
+		// Verify the structure was created
+		assert.FileExists(t, filepath.Join(tmpDir, ".ticketflow.yaml"))
+		assert.DirExists(t, filepath.Join(tmpDir, "tickets"))
+		assert.DirExists(t, filepath.Join(tmpDir, "tickets", "todo"))
+		assert.DirExists(t, filepath.Join(tmpDir, "tickets", "doing"))
+		assert.DirExists(t, filepath.Join(tmpDir, "tickets", "done"))
+
+		// Verify .gitignore was updated
+		gitignoreContent, err := os.ReadFile(filepath.Join(tmpDir, ".gitignore"))
+		require.NoError(t, err)
+		assert.Contains(t, string(gitignoreContent), "current-ticket.md")
+		assert.Contains(t, string(gitignoreContent), ".worktrees/")
+	})
+
+	t.Run("execute handles already initialized", func(t *testing.T) {
+		// Create a temporary directory for testing
+		tmpDir, err := os.MkdirTemp("", "ticketflow-init-test-already-*")
+		require.NoError(t, err)
+		defer os.RemoveAll(tmpDir)
+
+		// Change to temp directory
+		originalWd, err := os.Getwd()
+		require.NoError(t, err)
+		defer func() {
+			err := os.Chdir(originalWd)
+			require.NoError(t, err)
+		}()
+		require.NoError(t, os.Chdir(tmpDir))
+
+		// Initialize git repo
+		gitInit := exec.Command("git", "init")
+		gitInit.Dir = tmpDir
+		require.NoError(t, gitInit.Run())
+
+		// Configure git locally (not globally) for the test
+		gitConfig := exec.Command("git", "config", "user.name", "Test User")
+		gitConfig.Dir = tmpDir
+		require.NoError(t, gitConfig.Run())
+
+		gitConfigEmail := exec.Command("git", "config", "user.email", "test@example.com")
+		gitConfigEmail.Dir = tmpDir
+		require.NoError(t, gitConfigEmail.Run())
+
+		// Execute the init command first time
+		cmd := NewInitCommand()
+		err = cmd.Execute(context.Background(), nil, []string{})
+		require.NoError(t, err)
+
+		// Execute the init command second time
+		err = cmd.Execute(context.Background(), nil, []string{})
+		// Should succeed without error even when already initialized
+		assert.NoError(t, err)
+	})
+
+	t.Run("execute fails when not in git repo", func(t *testing.T) {
+		// Create a temporary directory for testing (without git init)
+		tmpDir, err := os.MkdirTemp("", "ticketflow-init-test-no-git-*")
+		require.NoError(t, err)
+		defer os.RemoveAll(tmpDir)
+
+		// Change to temp directory
+		originalWd, err := os.Getwd()
+		require.NoError(t, err)
+		defer func() {
+			err := os.Chdir(originalWd)
+			require.NoError(t, err)
+		}()
+		require.NoError(t, os.Chdir(tmpDir))
+
+		// Execute the init command without git repo
+		cmd := NewInitCommand()
+		err = cmd.Execute(context.Background(), nil, []string{})
+
+		// Should fail as not in a git repository
+		assert.Error(t, err)
+	})
+}

--- a/tickets/doing/250812-152902-migrate-init-command.md
+++ b/tickets/doing/250812-152902-migrate-init-command.md
@@ -15,15 +15,15 @@ Migrate the `init` command to use the new Command interface. This command initia
 ## Tasks
 Make sure to update task status when you finish it. Also, always create a commit for each task you finished.
 
-- [ ] Create `internal/cli/commands/init.go` implementing the Command interface
-- [ ] Handle the special case that init doesn't require existing config
-- [ ] Add unit tests for init command
-- [ ] Update main.go to use registry for init command
-- [ ] Remove init case from switch statement
-- [ ] Test init command in new directory
-- [ ] Run `make test` to run the tests
-- [ ] Run `make vet`, `make fmt` and `make lint`
-- [ ] Update migration guide with completion status
+- [x] Create `internal/cli/commands/init.go` implementing the Command interface
+- [x] Handle the special case that init doesn't require existing config
+- [x] Add unit tests for init command
+- [x] Update main.go to use registry for init command
+- [x] Remove init case from switch statement
+- [x] Test init command in new directory
+- [x] Run `make test` to run the tests
+- [x] Run `make vet`, `make fmt` and `make lint`
+- [x] Update migration guide with completion status
 - [ ] Get developer approval before closing
 
 ## Implementation Notes
@@ -39,3 +39,24 @@ Make sure to update task status when you finish it. Also, always create a commit
 - Review `internal/cli/commands/version.go` for example implementation
 - Check `cmd/ticketflow/executor.go` for command execution pattern
 - Note: Init command has special handling in the migration guide
+
+## Implementation Insights
+
+### What Went Well
+1. **Simple Migration**: The init command was straightforward to migrate since it has no flags and minimal logic
+2. **Code Reuse**: Successfully delegated to existing `cli.InitCommand(ctx)` function, avoiding code duplication
+3. **Test Coverage**: Comprehensive unit tests covering all scenarios (new init, already initialized, no git repo)
+4. **Clean Removal**: Removing the old switch case and `handleInit` function was clean with no complications
+
+### Key Learnings
+1. **Test .gitignore Content**: Initial test failed because it checked for wrong .gitignore content - the actual implementation adds "current-ticket.md" and ".worktrees/", not ".ticketflow.state"
+2. **Working Directory Context**: Integration tests need careful handling of working directory changes to avoid affecting the main repository
+3. **Linter Formatting**: `go fmt` automatically adds newlines at end of files - this is expected behavior
+
+### Migration Pattern Established
+- Commands without flags can have `SetupFlags` return nil
+- Commands without validation requirements can have `Validate` return nil immediately
+- Special commands that don't require config can still use the same interface pattern
+
+### Next Steps Recommendation
+Based on this migration, the `status` command would be a good next candidate as it's also relatively simple but introduces the App dependency pattern that many other commands will need.

--- a/tickets/doing/250812-152902-migrate-init-command.md
+++ b/tickets/doing/250812-152902-migrate-init-command.md
@@ -1,8 +1,8 @@
 ---
 priority: 2
-description: "Migrate init command to new Command interface"
+description: Migrate init command to new Command interface
 created_at: "2025-08-12T15:29:02+09:00"
-started_at: null
+started_at: "2025-08-12T18:21:49+09:00"
 closed_at: null
 related:
     - parent:250810-003001-refactor-command-interface

--- a/tickets/done/250812-152902-migrate-init-command.md
+++ b/tickets/done/250812-152902-migrate-init-command.md
@@ -3,7 +3,7 @@ priority: 2
 description: Migrate init command to new Command interface
 created_at: "2025-08-12T15:29:02+09:00"
 started_at: "2025-08-12T18:21:49+09:00"
-closed_at: null
+closed_at: "2025-08-12T20:34:13+09:00"
 related:
     - parent:250810-003001-refactor-command-interface
 ---

--- a/tickets/todo/250812-185538-migrate-status-command.md
+++ b/tickets/todo/250812-185538-migrate-status-command.md
@@ -1,0 +1,63 @@
+---
+priority: 2
+description: "Migrate status command to new Command interface"
+created_at: "2025-08-12T18:55:38+09:00"
+started_at: null
+closed_at: null
+related:
+    - parent:250810-003001-refactor-command-interface
+---
+
+# Migrate status command to new Command interface
+
+Migrate the `status` command to use the new Command interface. This is the first read-only command that requires App dependency, establishing the pattern for future migrations.
+
+## Tasks
+Make sure to update task status when you finish it. Also, always create a commit for each task you finished.
+
+- [ ] Create `internal/cli/commands/status.go` implementing the Command interface
+- [ ] Implement App dependency injection pattern (following migration guide)
+- [ ] Handle the -o/--output flag for JSON output format
+- [ ] Add comprehensive unit tests with mock App
+- [ ] Update main.go to register status command
+- [ ] Remove status case from switch statement
+- [ ] Test status command functionality (with and without current ticket)
+- [ ] Run `make test` to run the tests
+- [ ] Run `make vet`, `make fmt` and `make lint`
+- [ ] Update migration guide with completion status
+- [ ] Get developer approval before closing
+
+## Implementation Notes
+
+### Current Implementation
+- Located in switch statement around line 193 in main.go
+- Calls `handleStatus(ctx, format)` 
+- Has one flag: `-o` for output format (json/text)
+- Requires App instance to get current ticket status
+
+### Migration Requirements
+1. **App Dependency**: First command needing `cli.App` - establish factory pattern
+2. **Flag Handling**: Parse `-o` flag for output format
+3. **Error Handling**: Properly handle "no current ticket" scenario
+4. **Testing**: Mock App for unit tests
+
+### Expected Behavior
+- Shows current ticket information if one exists
+- Returns appropriate error if no current ticket
+- Supports JSON output format with `-o json` flag
+- Default text output shows ticket ID, status, description, and duration
+
+## References
+
+- See `docs/COMMAND_MIGRATION_GUIDE.md` section on "Commands with App Dependencies"
+- Review `internal/cli/commands/version.go` for basic command structure
+- Check current `handleStatus` implementation in main.go
+- App factory pattern example in migration guide
+
+## Why This Command Next?
+
+1. **Simple Read-Only**: No state modifications, lower risk
+2. **Establishes Pattern**: First command with App dependency
+3. **Single Flag**: Simple flag handling to implement
+4. **Quick Win**: Estimated 2-3 hours to complete
+5. **Foundation**: Pattern will be reused for list, show, and other commands


### PR DESCRIPTION
## Summary
- Migrated the `init` command to use the new Command interface pattern
- First special command that doesn't require existing config
- Establishes patterns for simple commands without flags

## Changes
- Created `internal/cli/commands/init.go` implementing the Command interface
- Added comprehensive unit tests covering all scenarios
- Registered init command in the command registry
- Removed legacy init case from switch statement and `handleInit` function
- Updated migration guide to mark init as completed

## Test Plan
- [x] Unit tests pass for init command
- [x] All existing tests pass (`make test`)
- [x] Code quality checks pass (`make vet`, `make fmt`, `make lint`)
- [x] Manually tested init command in new directory
- [x] Verified handling of already initialized repositories

## Related
- Parent ticket: #250810-003001-refactor-command-interface
- Migration guide: `docs/COMMAND_MIGRATION_GUIDE.md`

🤖 Generated with [Claude Code](https://claude.ai/code)