### PR TITLE
Migrate worktree command to new Command interface

### DIFF
--- a/internal/cli/commands/worktree.go
+++ b/internal/cli/commands/worktree.go
@@ -1,0 +1,114 @@
+package commands
+
+import (
+	"context"
+	"flag"
+	"fmt"
+
+	"github.com/yshrsmz/ticketflow/internal/command"
+)
+
+// WorktreeCommand implements the worktree parent command using the new Command interface
+type WorktreeCommand struct {
+	subcommands map[string]command.Command
+}
+
+// NewWorktreeCommand creates a new worktree command with its subcommands
+func NewWorktreeCommand() command.Command {
+	return &WorktreeCommand{
+		subcommands: map[string]command.Command{
+			"list":  NewWorktreeListCommand(),
+			"clean": NewWorktreeCleanCommand(),
+		},
+	}
+}
+
+// Name returns the command name
+func (c *WorktreeCommand) Name() string {
+	return "worktree"
+}
+
+// Aliases returns alternative names for this command
+func (c *WorktreeCommand) Aliases() []string {
+	return nil
+}
+
+// Description returns a short description of the command
+func (c *WorktreeCommand) Description() string {
+	return "Manage git worktrees associated with tickets"
+}
+
+// Usage returns the usage string for the command
+func (c *WorktreeCommand) Usage() string {
+	return "worktree <subcommand> [options]"
+}
+
+// SetupFlags configures the flag set for this command
+func (c *WorktreeCommand) SetupFlags(fs *flag.FlagSet) interface{} {
+	// No flags for the parent command
+	return nil
+}
+
+// Validate checks if the provided flags and arguments are valid
+func (c *WorktreeCommand) Validate(flags interface{}, args []string) error {
+	// We don't validate here - let subcommands handle their own validation
+	// If no subcommand is provided, we'll show usage in Execute
+	return nil
+}
+
+// Execute runs the command with the given context
+func (c *WorktreeCommand) Execute(ctx context.Context, flags interface{}, args []string) error {
+	if len(args) == 0 {
+		c.printUsage()
+		return nil
+	}
+
+	subcmdName := args[0]
+	subcmd, ok := c.subcommands[subcmdName]
+	if !ok {
+		c.printUsage()
+		return fmt.Errorf("unknown worktree subcommand: %s", subcmdName)
+	}
+
+	// Parse flags for the subcommand
+	fs := flag.NewFlagSet(fmt.Sprintf("worktree %s", subcmdName), flag.ExitOnError)
+	subcmdFlags := subcmd.SetupFlags(fs)
+
+	// Parse remaining arguments
+	if err := fs.Parse(args[1:]); err != nil {
+		return err
+	}
+
+	// Validate the subcommand
+	if err := subcmd.Validate(subcmdFlags, fs.Args()); err != nil {
+		return err
+	}
+
+	// Execute the subcommand
+	return subcmd.Execute(ctx, subcmdFlags, fs.Args())
+}
+
+// printUsage prints the usage information for the worktree command
+func (c *WorktreeCommand) printUsage() {
+	fmt.Println(`TicketFlow Worktree Management
+
+USAGE:
+  ticketflow worktree list [--format json]   List all worktrees
+  ticketflow worktree clean                   Remove orphaned worktrees
+
+DESCRIPTION:
+  The worktree command manages git worktrees associated with tickets.
+
+  list    Shows all worktrees with their paths, branches, and HEAD commits
+  clean   Removes worktrees that don't have corresponding active tickets
+
+EXAMPLES:
+  # List all worktrees
+  ticketflow worktree list
+
+  # List worktrees in JSON format
+  ticketflow worktree list --format json
+
+  # Clean up orphaned worktrees
+  ticketflow worktree clean`)
+}

--- a/internal/cli/commands/worktree.go
+++ b/internal/cli/commands/worktree.go
@@ -8,6 +8,11 @@ import (
 	"github.com/yshrsmz/ticketflow/internal/command"
 )
 
+const (
+	// errUnknownSubcommand is the error message for unknown worktree subcommands
+	errUnknownSubcommand = "unknown worktree subcommand: %s"
+)
+
 // WorktreeCommand implements the worktree parent command using the new Command interface
 type WorktreeCommand struct {
 	subcommands map[string]command.Command
@@ -67,7 +72,7 @@ func (c *WorktreeCommand) Execute(ctx context.Context, flags interface{}, args [
 	subcmd, ok := c.subcommands[subcmdName]
 	if !ok {
 		c.printUsage()
-		return fmt.Errorf("unknown worktree subcommand: %s", subcmdName)
+		return fmt.Errorf(errUnknownSubcommand, subcmdName)
 	}
 
 	// Parse flags for the subcommand

--- a/internal/cli/commands/worktree_clean.go
+++ b/internal/cli/commands/worktree_clean.go
@@ -1,0 +1,63 @@
+package commands
+
+import (
+	"context"
+	"flag"
+	"fmt"
+
+	"github.com/yshrsmz/ticketflow/internal/cli"
+	"github.com/yshrsmz/ticketflow/internal/command"
+)
+
+// WorktreeCleanCommand implements the worktree clean subcommand
+type WorktreeCleanCommand struct{}
+
+// NewWorktreeCleanCommand creates a new worktree clean command
+func NewWorktreeCleanCommand() command.Command {
+	return &WorktreeCleanCommand{}
+}
+
+// Name returns the command name
+func (c *WorktreeCleanCommand) Name() string {
+	return "clean"
+}
+
+// Aliases returns alternative names for this command
+func (c *WorktreeCleanCommand) Aliases() []string {
+	return nil
+}
+
+// Description returns a short description of the command
+func (c *WorktreeCleanCommand) Description() string {
+	return "Remove orphaned worktrees"
+}
+
+// Usage returns the usage string for the command
+func (c *WorktreeCleanCommand) Usage() string {
+	return "worktree clean"
+}
+
+// SetupFlags configures the flag set for this command
+func (c *WorktreeCleanCommand) SetupFlags(fs *flag.FlagSet) interface{} {
+	// No flags for the clean command
+	return nil
+}
+
+// Validate checks if the provided flags and arguments are valid
+func (c *WorktreeCleanCommand) Validate(flags interface{}, args []string) error {
+	// No additional arguments expected
+	if len(args) > 0 {
+		return fmt.Errorf("worktree clean command takes no arguments")
+	}
+	return nil
+}
+
+// Execute runs the command with the given context
+func (c *WorktreeCleanCommand) Execute(ctx context.Context, flags interface{}, args []string) error {
+	app, err := cli.NewApp(ctx)
+	if err != nil {
+		return err
+	}
+
+	return app.CleanWorktrees(ctx)
+}

--- a/internal/cli/commands/worktree_clean_test.go
+++ b/internal/cli/commands/worktree_clean_test.go
@@ -8,6 +8,7 @@ import (
 )
 
 func TestWorktreeCleanCommand_Interface(t *testing.T) {
+	t.Parallel()
 	cmd := NewWorktreeCleanCommand()
 
 	assert.Equal(t, "clean", cmd.Name())
@@ -17,6 +18,7 @@ func TestWorktreeCleanCommand_Interface(t *testing.T) {
 }
 
 func TestWorktreeCleanCommand_SetupFlags(t *testing.T) {
+	t.Parallel()
 	cmd := &WorktreeCleanCommand{}
 	fs := flag.NewFlagSet("test", flag.ContinueOnError)
 
@@ -27,6 +29,7 @@ func TestWorktreeCleanCommand_SetupFlags(t *testing.T) {
 }
 
 func TestWorktreeCleanCommand_Validate(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name        string
 		flags       interface{}

--- a/internal/cli/commands/worktree_clean_test.go
+++ b/internal/cli/commands/worktree_clean_test.go
@@ -1,0 +1,74 @@
+package commands
+
+import (
+	"flag"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestWorktreeCleanCommand_Interface(t *testing.T) {
+	cmd := NewWorktreeCleanCommand()
+
+	assert.Equal(t, "clean", cmd.Name())
+	assert.Nil(t, cmd.Aliases())
+	assert.Equal(t, "Remove orphaned worktrees", cmd.Description())
+	assert.Equal(t, "worktree clean", cmd.Usage())
+}
+
+func TestWorktreeCleanCommand_SetupFlags(t *testing.T) {
+	cmd := &WorktreeCleanCommand{}
+	fs := flag.NewFlagSet("test", flag.ContinueOnError)
+
+	flags := cmd.SetupFlags(fs)
+
+	// No flags for clean command
+	assert.Nil(t, flags)
+}
+
+func TestWorktreeCleanCommand_Validate(t *testing.T) {
+	tests := []struct {
+		name        string
+		flags       interface{}
+		args        []string
+		wantErr     bool
+		errContains string
+	}{
+		{
+			name:    "valid no arguments",
+			flags:   nil,
+			args:    []string{},
+			wantErr: false,
+		},
+		{
+			name:        "unexpected arguments",
+			flags:       nil,
+			args:        []string{"extra"},
+			wantErr:     true,
+			errContains: "takes no arguments",
+		},
+		{
+			name:        "multiple unexpected arguments",
+			flags:       nil,
+			args:        []string{"extra", "args"},
+			wantErr:     true,
+			errContains: "takes no arguments",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cmd := &WorktreeCleanCommand{}
+			err := cmd.Validate(tt.flags, tt.args)
+
+			if tt.wantErr {
+				assert.Error(t, err)
+				if tt.errContains != "" {
+					assert.Contains(t, err.Error(), tt.errContains)
+				}
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}

--- a/internal/cli/commands/worktree_list.go
+++ b/internal/cli/commands/worktree_list.go
@@ -9,6 +9,12 @@ import (
 	"github.com/yshrsmz/ticketflow/internal/command"
 )
 
+// Output format constants
+const (
+	formatText = "text"
+	formatJSON = "json"
+)
+
 // WorktreeListCommand implements the worktree list subcommand
 type WorktreeListCommand struct{}
 
@@ -46,8 +52,8 @@ type worktreeListFlags struct {
 // SetupFlags configures the flag set for this command
 func (c *WorktreeListCommand) SetupFlags(fs *flag.FlagSet) interface{} {
 	flags := &worktreeListFlags{}
-	fs.StringVar(&flags.format, "format", "text", "Output format (text, json)")
-	fs.StringVar(&flags.formatShort, "o", "text", "Output format (text, json)")
+	fs.StringVar(&flags.format, "format", formatText, "Output format (text, json)")
+	fs.StringVar(&flags.formatShort, "o", formatText, "Output format (text, json)")
 	return flags
 }
 
@@ -66,13 +72,13 @@ func (c *WorktreeListCommand) Validate(flags interface{}, args []string) error {
 	f := flags.(*worktreeListFlags)
 
 	// Handle short form
-	if f.formatShort != "" && f.formatShort != "text" {
+	if f.formatShort != "" && f.formatShort != formatText {
 		f.format = f.formatShort
 	}
 
-	// Validate format (empty string defaults to "text" which is valid)
-	if f.format != "" && f.format != "text" && f.format != "json" {
-		return fmt.Errorf("invalid format: %s (must be 'text' or 'json')", f.format)
+	// Validate format (empty string defaults to text which is valid)
+	if f.format != "" && f.format != formatText && f.format != formatJSON {
+		return fmt.Errorf("invalid format: %s (must be '%s' or '%s')", f.format, formatText, formatJSON)
 	}
 
 	return nil
@@ -81,7 +87,7 @@ func (c *WorktreeListCommand) Validate(flags interface{}, args []string) error {
 // Execute runs the command with the given context
 func (c *WorktreeListCommand) Execute(ctx context.Context, flags interface{}, args []string) error {
 	// Default format
-	format := "text"
+	format := formatText
 
 	if flags != nil {
 		f := flags.(*worktreeListFlags)

--- a/internal/cli/commands/worktree_list.go
+++ b/internal/cli/commands/worktree_list.go
@@ -1,0 +1,100 @@
+package commands
+
+import (
+	"context"
+	"flag"
+	"fmt"
+
+	"github.com/yshrsmz/ticketflow/internal/cli"
+	"github.com/yshrsmz/ticketflow/internal/command"
+)
+
+// WorktreeListCommand implements the worktree list subcommand
+type WorktreeListCommand struct{}
+
+// NewWorktreeListCommand creates a new worktree list command
+func NewWorktreeListCommand() command.Command {
+	return &WorktreeListCommand{}
+}
+
+// Name returns the command name
+func (c *WorktreeListCommand) Name() string {
+	return "list"
+}
+
+// Aliases returns alternative names for this command
+func (c *WorktreeListCommand) Aliases() []string {
+	return nil
+}
+
+// Description returns a short description of the command
+func (c *WorktreeListCommand) Description() string {
+	return "List all worktrees"
+}
+
+// Usage returns the usage string for the command
+func (c *WorktreeListCommand) Usage() string {
+	return "worktree list [--format json]"
+}
+
+// worktreeListFlags holds the flags for the worktree list command
+type worktreeListFlags struct {
+	format      string
+	formatShort string
+}
+
+// SetupFlags configures the flag set for this command
+func (c *WorktreeListCommand) SetupFlags(fs *flag.FlagSet) interface{} {
+	flags := &worktreeListFlags{}
+	fs.StringVar(&flags.format, "format", "text", "Output format (text, json)")
+	fs.StringVar(&flags.formatShort, "o", "text", "Output format (text, json)")
+	return flags
+}
+
+// Validate checks if the provided flags and arguments are valid
+func (c *WorktreeListCommand) Validate(flags interface{}, args []string) error {
+	// No additional arguments expected
+	if len(args) > 0 {
+		return fmt.Errorf("worktree list command takes no arguments")
+	}
+
+	// If flags is nil, there's nothing to validate
+	if flags == nil {
+		return nil
+	}
+
+	f := flags.(*worktreeListFlags)
+
+	// Handle short form
+	if f.formatShort != "" && f.formatShort != "text" {
+		f.format = f.formatShort
+	}
+
+	// Validate format (empty string defaults to "text" which is valid)
+	if f.format != "" && f.format != "text" && f.format != "json" {
+		return fmt.Errorf("invalid format: %s (must be 'text' or 'json')", f.format)
+	}
+
+	return nil
+}
+
+// Execute runs the command with the given context
+func (c *WorktreeListCommand) Execute(ctx context.Context, flags interface{}, args []string) error {
+	// Default format
+	format := "text"
+
+	if flags != nil {
+		f := flags.(*worktreeListFlags)
+		if f.format != "" {
+			format = f.format
+		}
+	}
+
+	app, err := cli.NewApp(ctx)
+	if err != nil {
+		return err
+	}
+
+	outputFormat := cli.ParseOutputFormat(format)
+	return app.ListWorktrees(ctx, outputFormat)
+}

--- a/internal/cli/commands/worktree_list_test.go
+++ b/internal/cli/commands/worktree_list_test.go
@@ -41,19 +41,19 @@ func TestWorktreeListCommand_Validate(t *testing.T) {
 	}{
 		{
 			name:    "valid text format",
-			flags:   &worktreeListFlags{format: "text"},
+			flags:   &worktreeListFlags{format: formatText},
 			args:    []string{},
 			wantErr: false,
 		},
 		{
 			name:    "valid json format",
-			flags:   &worktreeListFlags{format: "json"},
+			flags:   &worktreeListFlags{format: formatJSON},
 			args:    []string{},
 			wantErr: false,
 		},
 		{
 			name:    "valid short form json",
-			flags:   &worktreeListFlags{format: "text", formatShort: "json"},
+			flags:   &worktreeListFlags{format: formatText, formatShort: formatJSON},
 			args:    []string{},
 			wantErr: false,
 		},
@@ -66,7 +66,7 @@ func TestWorktreeListCommand_Validate(t *testing.T) {
 		},
 		{
 			name:        "unexpected arguments",
-			flags:       &worktreeListFlags{format: "text"},
+			flags:       &worktreeListFlags{format: formatText},
 			args:        []string{"extra"},
 			wantErr:     true,
 			errContains: "takes no arguments",
@@ -95,11 +95,11 @@ func TestWorktreeListCommand_ValidateFormatOverride(t *testing.T) {
 
 	// Test that short form overrides long form
 	flags := &worktreeListFlags{
-		format:      "text",
-		formatShort: "json",
+		format:      formatText,
+		formatShort: formatJSON,
 	}
 
 	err := cmd.Validate(flags, []string{})
 	assert.NoError(t, err)
-	assert.Equal(t, "json", flags.format)
+	assert.Equal(t, formatJSON, flags.format)
 }

--- a/internal/cli/commands/worktree_list_test.go
+++ b/internal/cli/commands/worktree_list_test.go
@@ -1,0 +1,105 @@
+package commands
+
+import (
+	"flag"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestWorktreeListCommand_Interface(t *testing.T) {
+	cmd := NewWorktreeListCommand()
+
+	assert.Equal(t, "list", cmd.Name())
+	assert.Nil(t, cmd.Aliases())
+	assert.Equal(t, "List all worktrees", cmd.Description())
+	assert.Equal(t, "worktree list [--format json]", cmd.Usage())
+}
+
+func TestWorktreeListCommand_SetupFlags(t *testing.T) {
+	cmd := &WorktreeListCommand{}
+	fs := flag.NewFlagSet("test", flag.ContinueOnError)
+
+	flags := cmd.SetupFlags(fs)
+
+	// Verify flags is of correct type
+	_, ok := flags.(*worktreeListFlags)
+	assert.True(t, ok, "SetupFlags should return *worktreeListFlags")
+
+	// Verify flags are registered
+	assert.NotNil(t, fs.Lookup("format"))
+	assert.NotNil(t, fs.Lookup("o"))
+}
+
+func TestWorktreeListCommand_Validate(t *testing.T) {
+	tests := []struct {
+		name        string
+		flags       interface{}
+		args        []string
+		wantErr     bool
+		errContains string
+	}{
+		{
+			name:    "valid text format",
+			flags:   &worktreeListFlags{format: "text"},
+			args:    []string{},
+			wantErr: false,
+		},
+		{
+			name:    "valid json format",
+			flags:   &worktreeListFlags{format: "json"},
+			args:    []string{},
+			wantErr: false,
+		},
+		{
+			name:    "valid short form json",
+			flags:   &worktreeListFlags{format: "text", formatShort: "json"},
+			args:    []string{},
+			wantErr: false,
+		},
+		{
+			name:        "invalid format",
+			flags:       &worktreeListFlags{format: "yaml"},
+			args:        []string{},
+			wantErr:     true,
+			errContains: "invalid format",
+		},
+		{
+			name:        "unexpected arguments",
+			flags:       &worktreeListFlags{format: "text"},
+			args:        []string{"extra"},
+			wantErr:     true,
+			errContains: "takes no arguments",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cmd := &WorktreeListCommand{}
+			err := cmd.Validate(tt.flags, tt.args)
+
+			if tt.wantErr {
+				assert.Error(t, err)
+				if tt.errContains != "" {
+					assert.Contains(t, err.Error(), tt.errContains)
+				}
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestWorktreeListCommand_ValidateFormatOverride(t *testing.T) {
+	cmd := &WorktreeListCommand{}
+
+	// Test that short form overrides long form
+	flags := &worktreeListFlags{
+		format:      "text",
+		formatShort: "json",
+	}
+
+	err := cmd.Validate(flags, []string{})
+	assert.NoError(t, err)
+	assert.Equal(t, "json", flags.format)
+}

--- a/internal/cli/commands/worktree_list_test.go
+++ b/internal/cli/commands/worktree_list_test.go
@@ -8,6 +8,7 @@ import (
 )
 
 func TestWorktreeListCommand_Interface(t *testing.T) {
+	t.Parallel()
 	cmd := NewWorktreeListCommand()
 
 	assert.Equal(t, "list", cmd.Name())
@@ -17,6 +18,7 @@ func TestWorktreeListCommand_Interface(t *testing.T) {
 }
 
 func TestWorktreeListCommand_SetupFlags(t *testing.T) {
+	t.Parallel()
 	cmd := &WorktreeListCommand{}
 	fs := flag.NewFlagSet("test", flag.ContinueOnError)
 
@@ -32,6 +34,7 @@ func TestWorktreeListCommand_SetupFlags(t *testing.T) {
 }
 
 func TestWorktreeListCommand_Validate(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name        string
 		flags       interface{}
@@ -91,6 +94,7 @@ func TestWorktreeListCommand_Validate(t *testing.T) {
 }
 
 func TestWorktreeListCommand_ValidateFormatOverride(t *testing.T) {
+	t.Parallel()
 	cmd := &WorktreeListCommand{}
 
 	// Test that short form overrides long form

--- a/internal/cli/commands/worktree_test.go
+++ b/internal/cli/commands/worktree_test.go
@@ -1,0 +1,86 @@
+package commands
+
+import (
+	"context"
+	"flag"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestWorktreeCommand_Interface(t *testing.T) {
+	cmd := NewWorktreeCommand()
+
+	assert.Equal(t, "worktree", cmd.Name())
+	assert.Nil(t, cmd.Aliases())
+	assert.Equal(t, "Manage git worktrees associated with tickets", cmd.Description())
+	assert.Equal(t, "worktree <subcommand> [options]", cmd.Usage())
+}
+
+func TestWorktreeCommand_SetupFlags(t *testing.T) {
+	cmd := &WorktreeCommand{}
+	fs := flag.NewFlagSet("test", flag.ContinueOnError)
+
+	flags := cmd.SetupFlags(fs)
+
+	// No flags for parent command
+	assert.Nil(t, flags)
+}
+
+func TestWorktreeCommand_Validate(t *testing.T) {
+	cmd := &WorktreeCommand{}
+
+	// Validate doesn't perform validation for parent command
+	err := cmd.Validate(nil, []string{})
+	assert.NoError(t, err)
+
+	err = cmd.Validate(nil, []string{"list"})
+	assert.NoError(t, err)
+
+	err = cmd.Validate(nil, []string{"unknown"})
+	assert.NoError(t, err)
+}
+
+func TestWorktreeCommand_Execute(t *testing.T) {
+	tests := []struct {
+		name        string
+		args        []string
+		wantErr     bool
+		errContains string
+	}{
+		{
+			name:    "no subcommand shows usage",
+			args:    []string{},
+			wantErr: false,
+		},
+		{
+			name:        "unknown subcommand",
+			args:        []string{"unknown"},
+			wantErr:     true,
+			errContains: "unknown worktree subcommand",
+		},
+		{
+			name:        "invalid subcommand",
+			args:        []string{"delete"},
+			wantErr:     true,
+			errContains: "unknown worktree subcommand",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cmd := NewWorktreeCommand()
+			err := cmd.Execute(context.Background(), nil, tt.args)
+
+			if tt.wantErr {
+				require.Error(t, err)
+				if tt.errContains != "" {
+					assert.Contains(t, err.Error(), tt.errContains)
+				}
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}

--- a/internal/cli/commands/worktree_test.go
+++ b/internal/cli/commands/worktree_test.go
@@ -10,6 +10,7 @@ import (
 )
 
 func TestWorktreeCommand_Interface(t *testing.T) {
+	t.Parallel()
 	cmd := NewWorktreeCommand()
 
 	assert.Equal(t, "worktree", cmd.Name())
@@ -19,6 +20,7 @@ func TestWorktreeCommand_Interface(t *testing.T) {
 }
 
 func TestWorktreeCommand_SetupFlags(t *testing.T) {
+	t.Parallel()
 	cmd := &WorktreeCommand{}
 	fs := flag.NewFlagSet("test", flag.ContinueOnError)
 
@@ -29,6 +31,7 @@ func TestWorktreeCommand_SetupFlags(t *testing.T) {
 }
 
 func TestWorktreeCommand_Validate(t *testing.T) {
+	t.Parallel()
 	cmd := &WorktreeCommand{}
 
 	// Validate doesn't perform validation for parent command
@@ -43,6 +46,7 @@ func TestWorktreeCommand_Validate(t *testing.T) {
 }
 
 func TestWorktreeCommand_Execute(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name        string
 		args        []string

--- a/tickets/doing/250814-181147-migrate-worktree-command.md
+++ b/tickets/doing/250814-181147-migrate-worktree-command.md
@@ -1,8 +1,8 @@
 ---
 priority: 3
-description: "Migrate worktree command with subcommands to new Command interface"
+description: Migrate worktree command with subcommands to new Command interface
 created_at: "2025-08-14T18:11:47+09:00"
-started_at: null
+started_at: "2025-08-15T10:41:24+09:00"
 closed_at: null
 related:
     - parent:250812-152927-migrate-remaining-commands

--- a/tickets/todo/250812-152927-migrate-remaining-commands.md
+++ b/tickets/todo/250812-152927-migrate-remaining-commands.md
@@ -99,22 +99,23 @@ Complete the migration of all remaining commands to the new Command interface an
   - Zero-argument pattern, simple implementation
   - All tests passing
 
-### Current Status (2025-08-14 19:00)
-**Migration Progress: ~90% Complete**
-- **10 commands migrated**: version, help, init, status, list, show, new, start, close, restore
+### Current Status (2025-08-15)
+**Migration Progress: 100% COMPLETE! 🎉**
+- **12 commands migrated**: version, help, init, status, list, show, new, start, close, restore, cleanup, worktree (with subcommands)
 - **1 command removed**: migrate (no longer needed - all tickets already migrated)
-- **2 commands remaining**: 
-  - Migrate cleanup command
-  - Migrate worktree command (with subcommands)
+- **0 commands remaining**: ALL COMMANDS SUCCESSFULLY MIGRATED
 
 ### Next Priority
 - ✅ **remove-migrate-command** (250814-181027) - COMPLETED: Removed all migrate command code
-- 📋 **migrate-cleanup-command** (250814-181107) - Straightforward migration
-- 📋 **migrate-worktree-command** (250814-181147) - Complex with subcommands, highest priority (3)
+- ✅ **migrate-cleanup-command** (250814-181107) - COMPLETED: Migrated to new Command interface
+- ✅ **migrate-worktree-command** (250814-181147) - COMPLETED: Successfully migrated with subcommand pattern
 
 ### Remaining Work
-- **2 commands to migrate**: cleanup, worktree (with subcommands)
-- **Final cleanup**: Remove old code, switch statement, update docs
+- ✅ **ALL MIGRATIONS COMPLETE** - No commands remaining
+- **Final cleanup needed**: 
+  - Remove parseAndExecute function from main.go (no longer needed)
+  - Clean up command.go file if not needed
+  - Final documentation review
 
 ### Key Insights from Migration
 1. **App methods only return errors** - Commands must gather data for JSON output


### PR DESCRIPTION
## Summary
- Successfully migrated the worktree command and its subcommands (list, clean) to the new Command interface pattern
- This completes the entire command migration project - all 12 commands now use the new interface
- Eliminated the old switch statement from main.go entirely

## Changes
### Implementation
- Created `WorktreeCommand` as parent command with subcommand routing
- Implemented `WorktreeListCommand` with format flag support (text/json)
- Implemented `WorktreeCleanCommand` for orphaned worktree cleanup
- Added comprehensive unit tests for all commands
- Removed old switch-based implementation from main.go

### Code Quality Improvements
- Added format constants (`formatText`, `formatJSON`) to eliminate magic strings
- Extracted error message as constant (`errUnknownSubcommand`)
- Added `t.Parallel()` to all unit tests for better performance
- Updated COMMAND_MIGRATION_GUIDE.md with detailed subcommand patterns

## Test Plan
- [x] All unit tests passing with parallel execution enabled
- [x] Integration tests passing
- [x] No race conditions detected (`go test -race`)
- [x] Code formatted with `go fmt`
- [x] Clean `go vet` and `golangci-lint` runs
- [x] Manual testing of worktree commands:
  - `ticketflow worktree list` - Lists all worktrees
  - `ticketflow worktree list --format json` - JSON output works
  - `ticketflow worktree clean` - Cleans orphaned worktrees

## Migration Milestone 🎉
**This PR completes the entire command migration project!**
- All 12 commands migrated: version, help, init, status, list, show, new, start, close, restore, cleanup, worktree
- Old switch statement completely eliminated
- Clean, maintainable architecture established

🤖 Generated with [Claude Code](https://claude.ai/code)