### PR TITLE
refactor: make workflow documentation project-agnostic

### DIFF
--- a/internal/cli/commands/resources/workflow.md
+++ b/internal/cli/commands/resources/workflow.md
@@ -1,9 +1,11 @@
-# TicketFlow Development Workflow
+# TicketFlow Workflow Guide
 
 ## Overview
 TicketFlow is a git worktree-based ticket management system that helps manage development tasks using a directory-based status tracking system (todo/doing/done).
 
-## Development Workflow for New Features
+This guide shows how to use ticketflow to manage tickets and development workflow in your project.
+
+## Workflow for Managing Tasks
 
 ### 1. Create a Feature Ticket
 ```bash
@@ -40,24 +42,29 @@ cd ../ticketflow.worktrees/<ticket-id>
 
 ### 5. Test Your Changes
 ```bash
-# Run tests
-make test
+# Run your project's tests
+# The exact commands depend on your project type:
+#   Node.js: npm test, yarn test
+#   Go: go test ./..., make test
+#   Rust: cargo test
+#   Python: pytest, python -m unittest
+#   Java: mvn test, gradle test
 
-# Run specific test suites if available
-make test-unit
-make test-integration
+<your-test-command>
 ```
 
 ### 6. Run Code Quality Checks
 ```bash
-# Format code
-make fmt
+# Run your project's code quality tools
+# The exact commands depend on your project:
+#   Node.js: npm run lint, prettier --write
+#   Go: go fmt ./..., go vet ./..., golangci-lint run
+#   Rust: cargo fmt, cargo clippy
+#   Python: black ., flake8, mypy
+#   Java: checkstyle, spotbugs
 
-# Run static analysis
-make vet
-
-# Run linter
-make lint
+<your-lint-command>
+<your-format-command>
 ```
 
 ### 7. Commit and Push Changes
@@ -145,10 +152,19 @@ TicketFlow is configured via .ticketflow.yaml in your repository root:
 # Example configuration
 worktrees:
   enabled: true
-  base_dir: ../ticketflow.worktrees
+  base_dir: ../<project>.worktrees
+  # Configure project-specific setup commands
   init_commands:
+    # Node.js projects:
     - npm install
-    - make build
+    # Go projects:
+    - go mod download
+    # Rust projects:
+    - cargo build
+    # Python projects:
+    - pip install -r requirements.txt
+    # Or any custom setup:
+    - ./scripts/setup.sh
 
 git:
   default_branch: main
@@ -156,6 +172,17 @@ git:
 tickets:
   directory: tickets
 ```
+
+### Project-Specific Commands
+
+The `init_commands` are executed automatically when you start work on a ticket. Configure these based on your project's needs:
+
+- **Node.js**: `npm install`, `npm run build`
+- **Go**: `go mod download`, `go build ./...`
+- **Rust**: `cargo fetch`, `cargo build`
+- **Python**: `pip install -r requirements.txt`, `python setup.py develop`
+- **Ruby**: `bundle install`
+- **Java**: `mvn install`, `gradle build`
 
 ## Tips and Best Practices
 
@@ -165,9 +192,11 @@ tickets:
 4. **Follow the workflow** - The structured approach helps maintain a clean git history
 5. **Regular cleanup** - Use `ticketflow cleanup` after PRs are merged to keep worktrees organized
 
-## Integration with AI Tools
+## Integration with Development Tools
 
-This workflow output can be integrated with various AI coding assistants:
+### AI Coding Assistants
+
+Export this workflow guide to help AI assistants understand your project workflow:
 
 ```bash
 # Save to Claude configuration
@@ -178,6 +207,26 @@ ticketflow workflow >> .cursorrules
 
 # Save to any AI tool configuration
 ticketflow workflow > .ai/instructions.md
+```
+
+### Custom Scripts
+
+You can integrate ticketflow with your project's build system:
+
+```bash
+# In package.json scripts:
+"scripts": {
+  "ticket:new": "ticketflow new",
+  "ticket:start": "ticketflow start",
+  "ticket:status": "ticketflow status"
+}
+
+# In Makefile:
+ticket-new:
+	ticketflow new $(ARGS)
+
+ticket-start:
+	ticketflow start $(ID)
 ```
 
 ## Getting Help

--- a/internal/cli/commands/workflow.go
+++ b/internal/cli/commands/workflow.go
@@ -38,7 +38,7 @@ func (c *WorkflowCommand) Aliases() []string {
 
 // Description returns a short description of the command
 func (c *WorkflowCommand) Description() string {
-	return "Print development workflow guide"
+	return "Print ticketflow workflow guide"
 }
 
 // Usage returns the usage string for the command

--- a/internal/cli/commands/workflow_integration_test.go
+++ b/internal/cli/commands/workflow_integration_test.go
@@ -89,9 +89,9 @@ func TestWorkflowCommand_Integration(t *testing.T) {
 	output := stdout.String()
 
 	// Check for main sections
-	assert.Contains(t, output, "# TicketFlow Development Workflow")
+	assert.Contains(t, output, "# TicketFlow Workflow Guide")
 	assert.Contains(t, output, "## Overview")
-	assert.Contains(t, output, "## Development Workflow for New Features")
+	assert.Contains(t, output, "## Workflow for Managing Tasks")
 
 	// Check for key workflow steps
 	assert.Contains(t, output, "### 1. Create a Feature Ticket")
@@ -104,12 +104,12 @@ func TestWorkflowCommand_Integration(t *testing.T) {
 	// Check for important commands
 	assert.Contains(t, output, "ticketflow close")
 	assert.Contains(t, output, "ticketflow cleanup")
-	assert.Contains(t, output, "make test")
-	assert.Contains(t, output, "make fmt")
-	assert.Contains(t, output, "make lint")
+	assert.Contains(t, output, "<your-test-command>")
+	assert.Contains(t, output, "<your-lint-command>")
+	assert.Contains(t, output, "<your-format-command>")
 
 	// Check for integration instructions
-	assert.Contains(t, output, "## Integration with AI Tools")
+	assert.Contains(t, output, "## Integration with Development Tools")
 	assert.Contains(t, output, "ticketflow workflow > CLAUDE.md")
 	assert.Contains(t, output, "ticketflow workflow >> .cursorrules")
 
@@ -176,6 +176,6 @@ func TestWorkflowCommand_OutputRedirection(t *testing.T) {
 	content, err := os.ReadFile(outputFile)
 	require.NoError(t, err)
 	assert.NotEmpty(t, content)
-	assert.Contains(t, string(content), "# TicketFlow Development Workflow")
+	assert.Contains(t, string(content), "# TicketFlow Workflow Guide")
 	assert.Contains(t, string(content), "ticketflow new my-feature")
 }

--- a/internal/cli/commands/workflow_test.go
+++ b/internal/cli/commands/workflow_test.go
@@ -15,7 +15,7 @@ func TestWorkflowCommand_Metadata(t *testing.T) {
 
 	assert.Equal(t, "workflow", cmd.Name())
 	assert.Nil(t, cmd.Aliases())
-	assert.Equal(t, "Print development workflow guide", cmd.Description())
+	assert.Equal(t, "Print ticketflow workflow guide", cmd.Description())
 	assert.Equal(t, "workflow", cmd.Usage())
 }
 
@@ -48,11 +48,11 @@ func TestWorkflowCommand_Execute(t *testing.T) {
 		output := buf.String()
 
 		// Verify the output starts with the expected header
-		assert.True(t, strings.HasPrefix(output, "# TicketFlow Development Workflow"))
+		assert.True(t, strings.HasPrefix(output, "# TicketFlow Workflow Guide"))
 
 		// Verify key sections are present
 		assert.Contains(t, output, "## Overview")
-		assert.Contains(t, output, "## Development Workflow for New Features")
+		assert.Contains(t, output, "## Workflow for Managing Tasks")
 		assert.Contains(t, output, "### 1. Create a Feature Ticket")
 		assert.Contains(t, output, "### 2. Start Work on the Ticket")
 		assert.Contains(t, output, "### 3. Navigate to the Worktree")
@@ -67,8 +67,8 @@ func TestWorkflowCommand_Execute(t *testing.T) {
 		assert.Contains(t, output, "```bash")
 		assert.Contains(t, output, "```")
 
-		// Verify AI integration section
-		assert.Contains(t, output, "## Integration with AI Tools")
+		// Verify development tools integration section
+		assert.Contains(t, output, "## Integration with Development Tools")
 		assert.Contains(t, output, "ticketflow workflow > CLAUDE.md")
 	})
 


### PR DESCRIPTION
## Summary
The workflow command was showing ticketflow development-specific commands (make test, make fmt, etc.), which confused users who wanted to use ticketflow as a tool for their own projects.

This PR makes the workflow documentation generic and applicable to any project using ticketflow as a ticket management tool.

## Changes
- Replace ticketflow-specific build commands with generic placeholders (`<your-test-command>`, `<your-lint-command>`)
- Add examples for different project types (Node.js, Go, Rust, Python, Java)
- Expand configuration section to show project-specific `init_commands` examples
- Update command description to "Print ticketflow workflow guide"
- Rename "Integration with AI Tools" to "Integration with Development Tools"

## Test Plan
- [x] Updated all test assertions to match new content
- [x] All workflow command tests pass successfully
- [x] Manually verified `ticketflow workflow` output shows generic commands

🤖 Generated with [Claude Code](https://claude.ai/code)