### PR TITLE
refactor: pin GitHub Actions to specific commit SHAs for security

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,12 +13,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v5
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           fetch-depth: 0
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
         with:
           go-version: '1.24'
 
@@ -29,7 +29,7 @@ jobs:
         run: make release-archives
 
       - name: Create Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@6cbd405e2c4e67a21c47fa9e383d020e4e28b836 # v2.3.3
         with:
           files: |
             dist/*.tar.gz

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,15 +16,15 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v5
+      uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
 
     - name: Set up Go
-      uses: actions/setup-go@v5
+      uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
       with:
         go-version: '1.24.x'
 
     - name: Cache Go modules
-      uses: actions/cache@v4
+      uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
       with:
         path: ~/go/pkg/mod
         key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
@@ -69,7 +69,7 @@ jobs:
 
     - name: Post coverage comment
       if: github.event_name == 'pull_request'
-      uses: actions/github-script@v7
+      uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
       with:
         script: |
           const coverage = process.env.COVERAGE;
@@ -139,14 +139,14 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v5
+      uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
 
     - name: Set up Go
-      uses: actions/setup-go@v5
+      uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
       with:
         go-version: '1.24.x'
 
     - name: Run golangci-lint
-      uses: golangci/golangci-lint-action@v8
+      uses: golangci/golangci-lint-action@4afd733a84b1f43292c63897423277bb7f4313a9 # v8.0.0
       with:
         version: latest


### PR DESCRIPTION
## Summary
- Replaced version tags with full commit SHA references for all GitHub Actions
- Improves security by preventing potential supply chain attacks through compromised tags
- Ensures reproducible builds with exact action versions

## Changes
Updated the following GitHub Actions to use commit SHAs:
- `actions/checkout@v5` → `08c6903cd8c0fde910a37f88322edcfb5dd907a8`
- `actions/setup-go@v5` → `d35c59abb061a4a6fb18e82ac0862c26744d6ab5`
- `actions/cache@v4` → `0400d5f644dc74513175e3cd8d07132dd4860809`
- `actions/github-script@v7` → `f28e40c7f34bde8b3046d885e986cb6290c5673b`
- `softprops/action-gh-release@v2` → `6cbd405e2c4e67a21c47fa9e383d020e4e28b836`
- `golangci/golangci-lint-action@v8` → `4afd733a84b1f43292c63897423277bb7f4313a9`

## Test plan
- [x] Verify workflow files are syntactically correct
- [ ] CI checks should pass on this PR
- [ ] Release workflow will be tested on next tag push

## Security Benefits
Using commit SHAs instead of tags provides:
1. **Immutability**: Commit SHAs cannot be moved or changed, unlike tags
2. **Supply chain security**: Prevents attacks where a compromised action maintainer moves a tag to malicious code
3. **Audit trail**: Exact version used is always clear and traceable

🤖 Generated with [Claude Code](https://claude.ai/code)