### PR TITLE
fix: disable GPG signing in tests and simplify pre-commit hook

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -47,7 +47,7 @@ The project uses Lefthook for git hooks management. Hooks are automatically inst
 - `make build` - Verifies build succeeds
 - `make lint` - Full linting
 
-To skip hooks temporarily: `git commit --no-verify` or `git push --no-verify`
+**IMPORTANT**: When committing/pushing code, you MUST pass all git hooks. Do not use `--no-verify` to skip them.
 
 ### Cross-platform builds
 ```bash
@@ -285,6 +285,7 @@ func TestCommand_Execute_Integration(t *testing.T) {
 - Integration tests provide meaningful coverage of Execute methods
 - Don't chase coverage percentages with mocks - prefer real behavior verification
 - Accept that some error paths may only be testable through integration tests
+- **IMPORTANT**: You must fix ALL test failures, no matter how small
 
 ### Git Configuration in Tests
 - **NEVER use `git config --global` in tests** - This modifies the user's git configuration and can cause commits with wrong authors

--- a/cmd/ticketflow/test_helpers.go
+++ b/cmd/ticketflow/test_helpers.go
@@ -59,6 +59,12 @@ func setupTestRepo(t *testing.T, tmpDir string) {
 	err = cmd.Run()
 	require.NoError(t, err)
 
+	// Disable GPG signing for test commits
+	cmd = exec.Command("git", "config", "commit.gpgSign", "false")
+	cmd.Dir = tmpDir
+	err = cmd.Run()
+	require.NoError(t, err)
+
 	cmd = exec.Command("git", "config", "init.defaultBranch", "main")
 	cmd.Dir = tmpDir
 	err = cmd.Run()

--- a/internal/cli/commands/testharness/harness.go
+++ b/internal/cli/commands/testharness/harness.go
@@ -52,6 +52,8 @@ func NewTestEnvironment(t *testing.T) *TestEnvironment {
 		env.RunGit("add", "README.md")
 		env.RunGit("config", "user.name", "Test User")
 		env.RunGit("config", "user.email", "test@example.com")
+		// Disable GPG signing for test commits
+		env.RunGit("config", "commit.gpgSign", "false")
 		env.RunGit("commit", "-m", "Initial commit")
 		// Now rename the branch to main
 		env.RunGit("branch", "-M", "main")
@@ -59,6 +61,8 @@ func NewTestEnvironment(t *testing.T) *TestEnvironment {
 		// Successfully created with main branch, now configure
 		env.RunGit("config", "user.name", "Test User")
 		env.RunGit("config", "user.email", "test@example.com")
+		// Disable GPG signing for test commits
+		env.RunGit("config", "commit.gpgSign", "false")
 		// Create initial commit to have a valid HEAD
 		env.WriteFile("README.md", "# Test Repository")
 		env.RunGit("add", "README.md")

--- a/internal/git/git_divergence_test.go
+++ b/internal/git/git_divergence_test.go
@@ -32,6 +32,10 @@ func initGitRepo(ctx context.Context, dir string) error {
 	if _, err := g.Exec(ctx, "config", "user.email", "test@example.com"); err != nil {
 		return err
 	}
+	// Disable GPG signing for test commits
+	if _, err := g.Exec(ctx, "config", "commit.gpgSign", "false"); err != nil {
+		return err
+	}
 
 	return nil
 }

--- a/scripts/githooks/pre-commit
+++ b/scripts/githooks/pre-commit
@@ -93,23 +93,13 @@ else
     print_success "All files properly formatted"
 fi
 
-# 2. Run go vet on staged files
+# 2. Run go vet using make
 print_info "Running go vet..."
-VET_ERRORS=""
-for FILE in $STAGED_GO_FILES; do
-    if [[ -f "$FILE" ]]; then
-        debug "Vetting: $FILE"
-        if ! go vet "$FILE" 2>&1; then
-            VET_ERRORS="yes"
-        fi
-    fi
-done
-
-if [[ -n "$VET_ERRORS" ]]; then
+if make vet 2>&1; then
+    print_success "go vet passed"
+else
     print_error "go vet found issues"
     exit 1
-else
-    print_success "go vet passed"
 fi
 
 # 3. Run golangci-lint (fast mode)

--- a/test/integration/workflow_test.go
+++ b/test/integration/workflow_test.go
@@ -27,6 +27,9 @@ func setupTestRepo(t *testing.T) string {
 	require.NoError(t, err)
 	_, err = cmd.Exec(context.Background(), "config", "user.email", "test@example.com")
 	require.NoError(t, err)
+	// Disable GPG signing for test commits
+	_, err = cmd.Exec(context.Background(), "config", "commit.gpgSign", "false")
+	require.NoError(t, err)
 
 	// Create initial commit
 	readmePath := filepath.Join(tmpDir, "README.md")


### PR DESCRIPTION
## Summary
- Fix test failures caused by GPG signing configuration
- Simplify pre-commit hook to use `make vet` for better maintainability
- Improve CLAUDE.md documentation organization

## Changes

### 1. Test Fixes
Added `commit.gpgSign false` configuration to all test repository setup functions to prevent GPG signing failures when developers have signing enabled globally:
- `test/integration/workflow_test.go`
- `cmd/ticketflow/test_helpers.go`
- `internal/cli/commands/testharness/harness.go`
- `internal/git/git_divergence_test.go`

### 2. Pre-commit Hook Simplification
- Changed from running `go vet` on individual files to using `make vet`
- This ensures consistency with the project's build system
- Simplifies maintenance and follows DRY principle

### 3. Documentation Improvements (CLAUDE.md)
- Moved test failure fix requirement to Testing Guidelines section
- Moved git hooks requirement to Git Hooks section
- Removed contradictory statement about using `--no-verify`

## Test Plan
- [x] All unit tests pass
- [x] All integration tests pass
- [x] Pre-commit hooks work correctly
- [x] Tests pass even with GPG signing enabled globally

## Impact
This ensures that:
- Tests pass reliably regardless of developer's git configuration
- Pre-commit hooks are simpler and more maintainable
- Documentation is clearer and better organized

🤖 Generated with [Claude Code](https://claude.ai/code)